### PR TITLE
Changes for 1.0.3.monetate.4: Add discovery timeout, remove pylibmc settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,14 @@ Your cache backend should look something like this::
             'LOCATION': 'cache-c.draaaf.cfg.use1.cache.amazonaws.com:11211',
             'OPTIONS': {
                 'IGNORE_CLUSTER_ERRORS': [True,False],
+                'behaviors': {  # pylibmc behaviors, passed to underlying client
+                    'ketama': True,
+                    'receive_timeout': 50,  # milliseconds, socket timeout for memcached reads
+                    'send_timeout': 50,  # milliseconds, socket timeout for memcached writes
+                },
             },
+            'DISCOVERY_TIMEOUT': 0.1,  # seconds, Elasticache discovery connection timeout
+            'TIMEOUT': 600,  # seconds, default memcached key expiration time if not specified in set()
         }
     }
 
@@ -55,7 +62,13 @@ The ``IGNORE_CLUSTER_ERRORS`` option is useful when ``LOCATION`` doesn't have su
 for ``config get cluster``. When set to ``True``, and ``config get cluster`` fails,
 it returns a list of a single node with the same endpoint supplied to ``LOCATION``.
 
-Django-elasticache changes default pylibmc params to increase performance.
+DISCOVERY_TIMEOUT controls how long to wait for response to any command during the
+discovery sequence, including initial connection and any subsequent commands. This is
+passed to the underlying socket used in the Telnet connection for communicating with
+the ElastiCache cluster. Measured in seconds.
+
+Django-elasticache does not change default pylibmc params. The user should set
+performance-related params in the cache configuration.
 
 Another solutions
 -----------------

--- a/django_elasticache/__init__.py
+++ b/django_elasticache/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (1, 0, 3, "monetate", 3)
+VERSION = (1, 0, 3, "monetate", 4)
 __version__ = '.'.join(map(str, VERSION))

--- a/django_elasticache/cluster_utils.py
+++ b/django_elasticache/cluster_utils.py
@@ -43,10 +43,11 @@ def get_cluster_info(host, port, discovery_timeout, ignore_cluster_errors=False)
     else:
         cmd = b'get AmazonElastiCache:cluster\n'
     client.write(cmd)
+    # note expect() does not use the client's socket timeout by default
     regex_index, match_object, res = client.expect([
         re.compile(b'\n\r\nEND\r\n'),
         re.compile(b'ERROR\r\n')
-    ])
+    ], timeout=discovery_timeout)
     client.close()
 
     if res == b'ERROR\r\n' and ignore_cluster_errors:


### PR DESCRIPTION
**Breaking change.**
Note that the changeset is a little misleading - some prior relevant changes were pushed to this fork's master directly. Diff against commit `5f93c06` (last upstream commit) to see the full changes. But the PR description is correct for the full changes.

## What
1. If the remote memcached is uncontactable, the library currently hangs until the global default socket timeout forces timeout of the telnet communication used for discovery commands.
2. Setting memcached/pylibmc options and behaviors shouldn't be done from library code.

## How
- Remove changes to pylibmc behaviors baked into the library. The user is now responsible for setting all pylibmc/memcached options. **This is a breaking change to behavior.**
- Add new `DISCOVERY_TIMEOUT` option controlling timeout during discovery process. 
- Add more details to documentation on how to set options in Django cache configuration.

## Verification:
Used debugger + iptables to block/unblock remote traffic with proper timing.
Cases tested to ensure that they respect read/write timeout settings and `DISCOVERY_TIMEOUT`:
- host does not resolve (exception when connecting, host not resolved)
- host resolves but can't connect / does not respond to any traffic (initial discovery telnet connection times out)
- host resolves and connects but stops responding to traffic during discovery (telnet read timeout on next discovery command)
- host resolves and connects but stops responding to traffic during normal operation (memcached read/writes in pylibmc time out)