### PR TITLE
Auto load django settings for tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,12 @@
+"""
+Package-level setup for the django-elasticache test suite.
+
+Configure Django settings before tests run.
+"""
+from django.conf import global_settings, settings
+
+
+def setup_package():
+    if not settings.configured:
+        settings.configure()
+    global_settings.configured = True

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,4 +1,4 @@
-from django.conf import global_settings, settings
+from django.conf import global_settings
 from nose.tools import eq_, raises
 import sys
 if sys.version < '3':
@@ -6,23 +6,18 @@ if sys.version < '3':
 else:
     from unittest.mock import patch, Mock
 
-
-# Initialize django 1.7
-settings.configure()
-global_settings.configured = True
+from django_elasticache.memcached import ElastiCache
 
 
 @raises(Exception)
 @patch('django.conf.settings', global_settings)
 def test_wrong_params():
-    from django_elasticache.memcached import ElastiCache
     ElastiCache('qew', {})
 
 
 @patch('django.conf.settings', global_settings)
 @patch('django_elasticache.memcached.get_cluster_info')
 def test_split_servers(get_cluster_info):
-    from django_elasticache.memcached import ElastiCache
     backend = ElastiCache('h:0', {})
     servers = ['h1:p', 'h2:p']
     get_cluster_info.return_value = {
@@ -37,7 +32,6 @@ def test_split_servers(get_cluster_info):
 @patch('django.conf.settings', global_settings)
 @patch('django_elasticache.memcached.get_cluster_info')
 def test_node_info_cache(get_cluster_info):
-    from django_elasticache.memcached import ElastiCache
     servers = ['h1:p', 'h2:p']
     get_cluster_info.return_value = {
         'nodes': servers
@@ -59,7 +53,6 @@ def test_node_info_cache(get_cluster_info):
 @patch('django.conf.settings', global_settings)
 @patch('django_elasticache.memcached.get_cluster_info')
 def test_invalidate_cache(get_cluster_info):
-    from django_elasticache.memcached import ElastiCache
     servers = ['h1:p', 'h2:p']
     get_cluster_info.return_value = {
         'nodes': servers


### PR DESCRIPTION
## Why

Test modules call `settings.configure()` inline and defer every `from django_elasticache.memcached import ...` into each test body. Without the deferral, `django.utils.encoding` (pulled in transitively) raises `ImproperlyConfigured` at module load because the inline `settings.configure()` runs after the top-of-file imports. The result is awkward per-test re-imports.

## How

Move `settings.configure()` into `setup_package()` in `tests/__init__.py` (nose's once-per-package hook). Drop the inline `settings.configure()` from `tests/test_backend.py` and hoist the `ElastiCache` import to module top. No test logic changes.

## Validation
```shell
>> nosetests
...........
----------------------------------------------------------------------
Ran 11 tests in 0.080s

OK
```
