### PR TITLE
Update tests for get_cluster_info signature

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -47,7 +47,7 @@ def test_split_servers(get_cluster_info):
     }
     backend._lib.Client = Mock()
     assert backend._cache
-    get_cluster_info.assert_called_once_with('h', '0', False)
+    get_cluster_info.assert_called_once_with('h', '0', None, False)
     backend._lib.Client.assert_called_once_with(servers)
 
 
@@ -70,7 +70,7 @@ def test_node_info_cache(get_cluster_info):
     eq_(backend._cache.get.call_count, 2)
     eq_(backend._cache.set.call_count, 2)
 
-    get_cluster_info.assert_called_once_with('h', '0', False)
+    get_cluster_info.assert_called_once_with('h', '0', None, False)
 
 
 @patch('django.conf.settings', global_settings)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -46,7 +46,7 @@ def test_happy_path(Telnet):
     client = Telnet.return_value
     client.read_until.side_effect = TEST_PROTOCOL_1_READ_UNTIL
     client.expect.side_effect = TEST_PROTOCOL_1_EXPECT
-    info = get_cluster_info('', 0)
+    info = get_cluster_info('', 0, None)
     eq_(info['version'], 1)
     eq_(info['nodes'], ['ip:port', 'host:port'])
 
@@ -54,7 +54,7 @@ def test_happy_path(Telnet):
 @raises(WrongProtocolData)
 @patch('django_elasticache.cluster_utils.Telnet', MagicMock())
 def test_bad_protocol():
-    get_cluster_info('', 0)
+    get_cluster_info('', 0, None)
 
 
 @patch('django_elasticache.cluster_utils.Telnet')
@@ -62,7 +62,7 @@ def test_last_versions(Telnet):
     client = Telnet.return_value
     client.read_until.side_effect = TEST_PROTOCOL_1_READ_UNTIL
     client.expect.side_effect = TEST_PROTOCOL_1_EXPECT
-    get_cluster_info('', 0)
+    get_cluster_info('', 0, None)
     client.write.assert_has_calls([
         call(b'version\n'),
         call(b'config get cluster\n'),
@@ -74,7 +74,7 @@ def test_prev_versions(Telnet):
     client = Telnet.return_value
     client.read_until.side_effect = TEST_PROTOCOL_2_READ_UNTIL
     client.expect.side_effect = TEST_PROTOCOL_2_EXPECT
-    get_cluster_info('', 0)
+    get_cluster_info('', 0, None)
     client.write.assert_has_calls([
         call(b'version\n'),
         call(b'get AmazonElastiCache:cluster\n'),
@@ -88,7 +88,7 @@ def test_ubuntu_protocol(Telnet):
     client.expect.side_effect = TEST_PROTOCOL_3_EXPECT
 
     try:
-        get_cluster_info('', 0)
+        get_cluster_info('', 0, None)
     except WrongProtocolData:
         raise AssertionError('Raised WrongProtocolData with Ubuntu version.')
 
@@ -103,7 +103,7 @@ def test_no_configuration_protocol_support_with_errors_ignored(Telnet):
     client = Telnet.return_value
     client.read_until.side_effect = TEST_PROTOCOL_4_READ_UNTIL
     client.expect.side_effect = TEST_PROTOCOL_4_EXPECT
-    info = get_cluster_info('test', 0, ignore_cluster_errors=True)
+    info = get_cluster_info('test', 0, None, ignore_cluster_errors=True)
     client.write.assert_has_calls([
         call(b'version\n'),
         call(b'config get cluster\n'),
@@ -118,7 +118,7 @@ def test_no_configuration_protocol_support_with_errors(Telnet):
     client = Telnet.return_value
     client.read_until.side_effect = TEST_PROTOCOL_4_READ_UNTIL
     client.expect.side_effect = TEST_PROTOCOL_4_EXPECT
-    get_cluster_info('test', 0, ignore_cluster_errors=False)
+    get_cluster_info('test', 0, None, ignore_cluster_errors=False)
     client.write.assert_has_calls([
         call(b'version\n'),
         call(b'config get cluster\n'),


### PR DESCRIPTION
## Why
```shell
======================================================================
ERROR: tests.test_protocol.test_bad_protocol
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/tools/nontrivial.py", line 60, in newfunc
    func(*arg, **kw)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_protocol.py", line 57, in test_bad_protocol
    get_cluster_info('', 0)
TypeError: get_cluster_info() takes at least 3 arguments (2 given)

======================================================================
ERROR: tests.test_protocol.test_happy_path
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_protocol.py", line 49, in test_happy_path
    info = get_cluster_info('', 0)
TypeError: get_cluster_info() takes at least 3 arguments (2 given)

======================================================================
ERROR: tests.test_protocol.test_last_versions
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_protocol.py", line 65, in test_last_versions
    get_cluster_info('', 0)
TypeError: get_cluster_info() takes at least 3 arguments (2 given)

======================================================================
ERROR: tests.test_protocol.test_no_configuration_protocol_support_with_errors
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/tools/nontrivial.py", line 60, in newfunc
    func(*arg, **kw)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_protocol.py", line 121, in test_no_configuration_protocol_support_with_errors
    get_cluster_info('test', 0, ignore_cluster_errors=False)
TypeError: get_cluster_info() takes at least 3 arguments (3 given)

======================================================================
ERROR: tests.test_protocol.test_no_configuration_protocol_support_with_errors_ignored
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_protocol.py", line 106, in test_no_configuration_protocol_support_with_errors_ignored
    info = get_cluster_info('test', 0, ignore_cluster_errors=True)
TypeError: get_cluster_info() takes at least 3 arguments (3 given)

======================================================================
ERROR: tests.test_protocol.test_prev_versions
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_protocol.py", line 77, in test_prev_versions
    get_cluster_info('', 0)
TypeError: get_cluster_info() takes at least 3 arguments (2 given)

======================================================================
ERROR: tests.test_protocol.test_ubuntu_protocol
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_protocol.py", line 91, in test_ubuntu_protocol
    get_cluster_info('', 0)
TypeError: get_cluster_info() takes at least 3 arguments (2 given)

======================================================================
FAIL: tests.test_backend.test_node_info_cache
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_backend.py", line 73, in test_node_info_cache
    get_cluster_info.assert_called_once_with('h', '0', False)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 957, in assert_called_once_with
    return self.assert_called_with(*args, **kwargs)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 944, in assert_called_with
    six.raise_from(AssertionError(_error_message(cause)), cause)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/six.py", line 759, in raise_from
    raise value
AssertionError: expected call not found.
Expected: get_cluster_info('h', '0', False)
Actual: get_cluster_info('h', '0', None, False)

======================================================================
FAIL: tests.test_backend.test_split_servers
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_backend.py", line 50, in test_split_servers
    get_cluster_info.assert_called_once_with('h', '0', False)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 957, in assert_called_once_with
    return self.assert_called_with(*args, **kwargs)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 944, in assert_called_with
    six.raise_from(AssertionError(_error_message(cause)), cause)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/six.py", line 759, in raise_from
    raise value
AssertionError: expected call not found.
Expected: get_cluster_info('h', '0', False)
Actual: get_cluster_info('h', '0', None, False)
```

## How
Fix incorrect `get_cluster_info` calls.