### PR TITLE
Remove obsolete BINARY handling tests

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -12,28 +12,11 @@ settings.configure()
 global_settings.configured = True
 
 
-@patch('django.conf.settings', global_settings)
-def test_patch_params():
-    from django_elasticache.memcached import ElastiCache
-    params = {}
-    ElastiCache('qew:12', params)
-    eq_(params['BINARY'], True)
-    eq_(params['OPTIONS']['tcp_nodelay'], True)
-    eq_(params['OPTIONS']['ketama'], True)
-
-
 @raises(Exception)
 @patch('django.conf.settings', global_settings)
 def test_wrong_params():
     from django_elasticache.memcached import ElastiCache
     ElastiCache('qew', {})
-
-
-@raises(Warning)
-@patch('django.conf.settings', global_settings)
-def test_wrong_params_warning():
-    from django_elasticache.memcached import ElastiCache
-    ElastiCache('qew', {'BINARY': False})
 
 
 @patch('django.conf.settings', global_settings)


### PR DESCRIPTION
## Why
```shell
======================================================================
ERROR: tests.test_backend.test_patch_params
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_backend.py", line 20, in test_patch_params
    eq_(params['BINARY'], True)
KeyError: 'BINARY'

======================================================================
ERROR: tests.test_backend.test_wrong_params_warning
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/nose/tools/nontrivial.py", line 60, in newfunc
    func(*arg, **kw)
  File "/Users/riccardomaio/.pyenv/versions/2.7.18/envs/django-elasticache/lib/python2.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/Users/riccardomaio/monetate-claude/django-elasticache/tests/test_backend.py", line 36, in test_wrong_params_warning
    ElastiCache('qew', {'BINARY': False})
  File "/Users/riccardomaio/monetate-claude/django-elasticache/django_elasticache/memcached.py", line 38, in __init__
    'Server configuration should be in format IP:port')
InvalidCacheBackendError: Server configuration should be in format IP:port
```

## How
Remove obsolete tests. The asserted behavior (BINARY/tcp_nodelay/ketama auto-patching and the BINARY=False warning) no longer exists in `ElastiCache.__init__`.
