### PR TITLE
Use pylibmc ClientPool for shared thread-safety

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Your cache backend should look something like this::
                 },
             },
             'DISCOVERY_TIMEOUT': 0.1,  # seconds, Elasticache discovery connection timeout
+            'POOL_SIZE': 8,  # pylibmc clients pooled per process; see Thread safety
             'TIMEOUT': 600,  # seconds, default memcached key expiration time if not specified in set()
         }
     }
@@ -73,17 +74,27 @@ performance-related params in the cache configuration.
 Thread safety
 -------------
 
-``ElastiCache`` stores its ``pylibmc.Client`` in a ``threading.local`` so each
-thread that uses the cache lazily builds and reuses its own client. Cluster-node
-discovery results stay shared on the instance; only the client connections are
-per thread.
+``pylibmc`` releases the GIL during socket I/O, so a single ``pylibmc.Client``
+shared across threads can have its reads and writes interleave on the same
+connection, causing intermittent libmemcached errors (protocol desync /
+``MEMCACHED_END``, ``EBADF``, "No active_fd" timeouts). A ``pylibmc.Client`` is
+not safe to share between threads.
 
-``pylibmc`` releases the GIL during socket I/O, so a shared ``pylibmc.Client``
-across threads can have its reads and writes interleave on the same connection,
-causing intermittent libmemcached errors (protocol desync / ``MEMCACHED_END``,
-``EBADF``, "No active_fd" timeouts). The per-thread storage sidesteps this at
-the cost of one open client per worker thread instead of one per process. No
-opt-in is required.
+``ElastiCache`` keeps a bounded ``pylibmc.ClientPool`` per process and reserves
+a client from it for each cache operation, so no client is used by two threads
+at once. Open connections per cluster node are therefore ``POOL_SIZE *
+processes-per-box * boxes``, bounded by the pool size rather than the worker
+thread count. Cluster-node discovery results stay shared on the instance; only
+the client connections are pooled.
+
+``POOL_SIZE`` and ``POOL_TIMEOUT_MS`` are top-level cache options (siblings of
+``OPTIONS``, like ``DISCOVERY_TIMEOUT``). ``POOL_SIZE`` defaults to 8.
+``POOL_TIMEOUT_MS`` (milliseconds) defaults to 1000 and controls how long an
+operation waits for a free client before raising ``Queue.Empty``
+(``queue.Empty`` in python 3). The wait is NOT bounded by the pylibmc
+``connect_timeout`` / ``send_timeout`` / ``receive_timeout`` behaviors as those
+only apply during socket I/O after a client is obtained. Both must be plain
+positive integers.
 
 Another solutions
 -----------------

--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -1,26 +1,89 @@
 """
-Backend for django cache
+Backend for django cache.
+
+``pylibmc.Client`` is not thread-safe: pylibmc releases the GIL during socket I/O, so two threads sharing one
+client interleave reads and writes on the same connection and desync the protocol. ``ElastiCache`` addresses this
+by keeping a bounded ``pylibmc.ClientPool`` per process and handing each operation its own client from the pool,
+so connection count is ``POOL_SIZE * processes-per-box * boxes`` rather than one-per-thread.
+
+Top-level configuration params (siblings of ``OPTIONS``, like ``DISCOVERY_TIMEOUT``):
+
+- ``POOL_SIZE`` (int, default 8): number of pooled clients per process.
+- ``POOL_TIMEOUT_MS`` (int, milliseconds, default 1000): how long to wait for a free client before raising
+  ``QueueEmpty``. Callers such as ``KeyCheckingMemcache`` catch and handle this like any other cache error.
+
+The pool is built lazily on first use (cluster discovery must happen first) under a lock so concurrent first
+calls do not each build their own pool.
 """
 import socket
+import sys
 import threading
 from functools import wraps
 from django.core.cache import InvalidCacheBackendError
 from django.core.cache.backends.memcached import PyLibMCCache
 from .cluster_utils import get_cluster_info
 
+if sys.version_info[0] < 3:
+    from Queue import Empty as QueueEmpty
+else:
+    from queue import Empty as QueueEmpty
+
+# Number of pooled pylibmc.Client objects per backend instance per process.
+DEFAULT_POOL_SIZE = 8
+
+# On exhaustion raises QueueEmpty.
+DEFAULT_POOL_TIMEOUT_MS = 1000
+
+
+def _validate_positive_int(name, value):
+    # Explicitly check bool since it is a subclass of int in Python.
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise InvalidCacheBackendError("{0} must be a positive integer, got {1!r}".format(name, value))
+    return int(value)
+
 
 def invalidate_cache_after_error(f):
-    """
-    catch any exception and invalidate internal cache with list of nodes
+    """Catch exceptions from cache operations and invalidate the cluster node cache and client pool so both are
+    rebuilt on the next call. QueueEmpty (pool exhaustion) is re-raised without invalidating since it is not a
+    topology error.
     """
     @wraps(f)
     def wrapper(self, *args, **kwds):
         try:
             return f(self, *args, **kwds)
+        except QueueEmpty:  # Don't clear cluster nodes on pool exhaustion.
+            raise
+        # TODO: Narrow to only invalidate on system/network-level errors. Clearing nodes on any exception is too broad
+        # and causes unnecessary rediscovery churn.
         except Exception:
             self.clear_cluster_nodes_cache()
             raise
     return wrapper
+
+
+class PooledClient(object):
+    """Proxy that routes each cache operation through a pylibmc.ClientPool reservation.
+
+    Django's BaseMemcachedCache calls operations directly on whatever ``_cache`` returns (e.g.
+    ``self._cache.get(key)``). Returning this proxy makes every such call check a client out of the pool, run
+    the operation, and return the client, so the number of live pylibmc.Client objects (open connections) is bounded by
+    the pool size rather than by the worker thread count.
+    """
+
+    def __init__(self, pool, timeout=None):
+        self.pool = pool
+        self.timeout = timeout  # Seconds to wait for a free client before raising QueueEmpty.
+
+    def __getattr__(self, name):
+        def call(*args, **kwargs):
+            # ClientPool is a Queue subclass. Call get()/put() directly rather than reserve() because it does not expose
+            # a timeout parameter. Raises QueueEmpty on pool exhaustion; callers (e.g. KeyCheckingMemcache) handle it.
+            mc = self.pool.get(block=True, timeout=self.timeout)
+            try:
+                return getattr(mc, name)(*args, **kwargs)
+            finally:
+                self.pool.put(mc)
+        return call
 
 
 class ElastiCache(PyLibMCCache):
@@ -49,16 +112,24 @@ class ElastiCache(PyLibMCCache):
         self._ignore_cluster_errors = self._options.get(
             'IGNORE_CLUSTER_ERRORS', False)
 
-        # pylibmc.Client is NOT thread-safe: pylibmc releases the GIL during socket I/O, so two threads using the same
-        # Client can interleave reads and writes on the same connection and desync the protocol (MEMCACHED_END where
-        # STORED was expected, EBADF on a socket another thread tore down, MEMCACHED_TIMEOUT "No active_fd"). Store the
-        # Client in a threading.local so each thread gets its own.
-        self._local = threading.local()
+        self.pool_size = _validate_positive_int("POOL_SIZE", params.get("POOL_SIZE", DEFAULT_POOL_SIZE))
+        self.pool_timeout = _validate_positive_int(
+            "POOL_TIMEOUT_MS", params.get("POOL_TIMEOUT_MS", DEFAULT_POOL_TIMEOUT_MS)
+        ) / 1000.0  # Python's Queue.get(timeout) takes seconds.
+
+        self._pool_lock = threading.Lock()
+        self._pool_proxy = None
 
     def clear_cluster_nodes_cache(self):
-        """clear internal cache with list of nodes in cluster"""
-        if hasattr(self, '_cluster_nodes_cache'):
-            del self._cluster_nodes_cache
+        """Clear the cached cluster node list and drop the client pool so both are rebuilt on next use.
+
+        Acquires _pool_lock so a concurrent _cache build that already fetched stale nodes cannot overwrite
+        the cleared _pool_proxy after this method returns.
+        """
+        with self._pool_lock:
+            if hasattr(self, '_cluster_nodes_cache'):
+                del self._cluster_nodes_cache
+            self._pool_proxy = None
 
     def get_cluster_nodes(self):
         """
@@ -78,24 +149,24 @@ class ElastiCache(PyLibMCCache):
 
     @property
     def _cache(self):
-        # pylibmc.Client is cached per-thread on self._local to avoid the cross-thread protocol-desync race. Cluster
-        # node discovery results stay shared on the instance via get_cluster_nodes(), only the client connections become
-        # per thread.
-        # See django-pylibmc: https://github.com/django-pylibmc/django-pylibmc/blob/master/django_pylibmc/memcached.py
-        client = getattr(self._local, 'client', None)
-        if client:
-            return client
+        # _pool_proxy is safe to read without the lock, only written under _pool_lock during initialization.
+        if self._pool_proxy is not None:
+            return self._pool_proxy
 
-        client = self._lib.Client(self.get_cluster_nodes())
-        if self._options:
-            # In Django 1.11, all behaviors are shifted into a behaviors dict
-            # Attempt to get from there, and fall back to old behavior if the behaviors
-            # key does not exist
-            client.behaviors = self._options.get('behaviors', self._options)
+        with self._pool_lock:
+            # Re-check, another thread may have built the pool while waiting for the lock.
+            if self._pool_proxy is not None:
+                return self._pool_proxy
 
-        self._local.client = client
+            master = self._lib.Client(self.get_cluster_nodes())
+            if self._options:
+                # In Django 1.11, all behaviors are shifted into a behaviors dict. Attempt to get from there, and fall
+                # back to old behavior if the behaviors key does not exist.
+                master.behaviors = self._options.get("behaviors", self._options)
 
-        return client
+            pool = self._lib.ClientPool(master, self.pool_size)
+            self._pool_proxy = PooledClient(pool, self.pool_timeout)
+            return self._pool_proxy
 
     @invalidate_cache_after_error
     def get(self, *args, **kwargs):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4,16 +4,95 @@ from nose.tools import eq_, raises
 import sys
 if sys.version < '3':
     from mock import patch, Mock
+    from Queue import Empty as QueueEmpty
 else:
+    from queue import Empty as QueueEmpty
     from unittest.mock import patch, Mock
 
 from django_elasticache.memcached import ElastiCache
+from django.core.cache import InvalidCacheBackendError
 
 
 @raises(Exception)
 @patch('django.conf.settings', global_settings)
 def test_wrong_params():
     ElastiCache('qew', {})
+
+
+@raises(InvalidCacheBackendError)
+@patch('django.conf.settings', global_settings)
+def test_invalid_pool_size_string():
+    ElastiCache('h:0', {'POOL_SIZE': 'not-a-number'})
+
+
+@raises(InvalidCacheBackendError)
+@patch('django.conf.settings', global_settings)
+def test_invalid_pool_size_zero():
+    ElastiCache('h:0', {'POOL_SIZE': 0})
+
+
+@raises(InvalidCacheBackendError)
+@patch('django.conf.settings', global_settings)
+def test_invalid_pool_size_float():
+    ElastiCache('h:0', {'POOL_SIZE': 3.7})
+
+
+@raises(InvalidCacheBackendError)
+@patch('django.conf.settings', global_settings)
+def test_invalid_pool_size_bool():
+    ElastiCache('h:0', {'POOL_SIZE': True})
+
+
+@raises(InvalidCacheBackendError)
+@patch('django.conf.settings', global_settings)
+def test_invalid_pool_timeout_negative():
+    ElastiCache('h:0', {'POOL_TIMEOUT_MS': -1})
+
+
+@raises(InvalidCacheBackendError)
+@patch('django.conf.settings', global_settings)
+def test_invalid_pool_timeout_zero():
+    ElastiCache('h:0', {'POOL_TIMEOUT_MS': 0})
+
+
+@raises(InvalidCacheBackendError)
+@patch('django.conf.settings', global_settings)
+def test_invalid_pool_timeout_float():
+    ElastiCache('h:0', {'POOL_TIMEOUT_MS': 1.5})
+
+
+@raises(InvalidCacheBackendError)
+@patch('django.conf.settings', global_settings)
+def test_invalid_pool_timeout_bool():
+    ElastiCache('h:0', {'POOL_TIMEOUT_MS': True})
+
+
+@raises(QueueEmpty)
+@patch('django.conf.settings', global_settings)
+@patch('django_elasticache.memcached.get_cluster_info')
+def test_pool_timeout_raises_queue_empty(get_cluster_info):
+    get_cluster_info.return_value = {'nodes': ['h:p']}
+    backend = ElastiCache('h:0', {'POOL_TIMEOUT_MS': 50})
+    backend._lib.Client = Mock()
+    mock_pool = Mock()
+    mock_pool.get.side_effect = QueueEmpty()
+    backend._lib.ClientPool = Mock(return_value=mock_pool)
+    backend.get('k')
+
+
+@patch('django.conf.settings', global_settings)
+@patch('django_elasticache.memcached.get_cluster_info')
+def test_pool_timeout_passed_to_get(get_cluster_info):
+    # POOL_TIMEOUT_MS=500ms should reach pool.get() as timeout=0.5 seconds.
+    get_cluster_info.return_value = {'nodes': ['h:p']}
+    backend = ElastiCache('h:0', {'POOL_TIMEOUT_MS': 500})
+    mock_client = Mock()
+    backend._lib.Client = Mock()
+    mock_pool = Mock()
+    mock_pool.get.return_value = mock_client
+    backend._lib.ClientPool = Mock(return_value=mock_pool)
+    backend.get('k')
+    mock_pool.get.assert_called_once_with(block=True, timeout=0.5)
 
 
 @patch('django.conf.settings', global_settings)
@@ -39,16 +118,26 @@ def test_node_info_cache(get_cluster_info):
     }
 
     backend = ElastiCache('h:0', {})
+    mock_client = Mock()
     backend._lib.Client = Mock()
+    mock_pool = Mock()
+    mock_pool.get.return_value = mock_client
+    backend._lib.ClientPool = Mock(return_value=mock_pool)
+
     backend.set('key1', 'val')
     backend.get('key1')
     backend.set('key2', 'val')
     backend.get('key2')
-    backend._lib.Client.assert_called_once_with(servers)
-    eq_(backend._cache.get.call_count, 2)
-    eq_(backend._cache.set.call_count, 2)
 
+    # The cluster is discovered once and the master client is built once.
     get_cluster_info.assert_called_once_with('h', '0', None, False)
+    backend._lib.Client.assert_called_once_with(servers)
+
+    # Every op checks out a client via pool.get() and returns it via pool.put().
+    eq_(mock_pool.get.call_count, 4)
+    eq_(mock_pool.put.call_count, 4)
+    eq_(mock_client.get.call_count, 2)
+    eq_(mock_client.set.call_count, 2)
 
 
 @patch('django.conf.settings', global_settings)
@@ -60,47 +149,84 @@ def test_invalidate_cache(get_cluster_info):
     }
 
     backend = ElastiCache('h:0', {})
+    mock_client = Mock()
+    mock_client.get.side_effect = Exception()
     backend._lib.Client = Mock()
-    assert backend._cache
-    backend._cache.get = Mock()
-    backend._cache.get.side_effect = Exception()
+    mock_pool = Mock()
+    mock_pool.get.return_value = mock_client
+    # return_value so both pool builds (before and after the error-triggered clear) get the same mock_pool.
+    backend._lib.ClientPool = Mock(return_value=mock_pool)
+
     try:
         backend.get('key1', 'val')
     except Exception:
         pass
-    #  invalidate cached client
-    backend._local.client = None
+    # On error the node cache and pool are dropped, so the next op rediscovers the cluster and rebuilds.
     try:
         backend.get('key1', 'val')
     except Exception:
         pass
-    eq_(backend._cache.get.call_count, 2)
+    eq_(mock_client.get.call_count, 2)
     eq_(get_cluster_info.call_count, 2)
 
 
 @patch("django.conf.settings", global_settings)
 @patch("django_elasticache.memcached.get_cluster_info")
-def test_client_is_per_thread(get_cluster_info):
+def test_pool_is_bounded(get_cluster_info):
+    get_cluster_info.return_value = {"nodes": ["h1:p", "h2:p"]}
+    backend = ElastiCache("h:0", {"POOL_SIZE": 3})
+    backend._lib.Client = Mock()
+
+    # Mock ClientPool so the test stays isolated from pylibmc internals (e.g. how/when fill() clones clients).
+    mock_pool = Mock()
+    mock_pool.get.return_value = backend._lib.Client.return_value
+    backend._lib.ClientPool = Mock(return_value=mock_pool)
+
+    for _ in range(40):
+        backend.get("k")
+
+    # Pool is constructed with the master client and the configured POOL_SIZE.
+    backend._lib.ClientPool.assert_called_once_with(backend._lib.Client.return_value, 3)
+    # Every op checks out via pool.get() and returns via pool.put().
+    eq_(mock_pool.get.call_count, 40)
+    eq_(mock_pool.put.call_count, 40)
+
+
+@patch("django.conf.settings", global_settings)
+@patch("django_elasticache.memcached.get_cluster_info")
+def test_pool_built_once_under_concurrent_first_use(get_cluster_info):
+    # Verify that two threads racing on the first _cache access both pass the outer
+    # `if self._pool_proxy is not None` check, but only one builds the pool.
     get_cluster_info.return_value = {"nodes": ["h1:p", "h2:p"]}
     backend = ElastiCache("h:0", {})
-    # Each call to the Client constructor returns a distinct mock so we can tell threads apart.
-    backend._lib.Client = Mock(side_effect=lambda *a, **k: Mock())
+    backend._lib.Client = Mock()
 
-    clients = {}
+    # Count how many times ClientPools are constructed using a thread-safe counter.
+    pool_build_count = [0]  # Using list for nonlocal mutability in Python 2.
+    lock = threading.Lock()
 
-    def grab(name):
-        clients[name] = backend._cache
+    def make_pool(*args, **kwargs):
+        with lock:
+            pool_build_count[0] += 1
+        pool = Mock()
+        pool.get.return_value = Mock()
+        return pool
 
-    main_client = backend._cache
-    t1 = threading.Thread(target=grab, args=("t1",))
-    t2 = threading.Thread(target=grab, args=("t2",))
-    t1.start()
-    t1.join()
-    t2.start()
-    t2.join()
+    backend._lib.ClientPool = Mock(side_effect=make_pool)
 
-    # main, t1, t2 each built their own client.
-    assert clients["t1"] is not clients["t2"]
-    assert clients["t1"] is not main_client
-    assert clients["t2"] is not main_client
-    eq_(backend._lib.Client.call_count, 3)
+    # Use an Event to hold both threads at the starting line so they hit _cache simultaneously.
+    start = threading.Event()
+
+    def access_cache():
+        start.wait()
+        backend._cache  # noqa: B018
+
+    threads = [threading.Thread(target=access_cache) for _ in range(8)]
+    for t in threads:
+        t.start()
+    start.set()
+    for t in threads:
+        t.join()
+
+    # Despite 8 threads racing, the pool must be built exactly once.
+    eq_(pool_build_count[0], 1)


### PR DESCRIPTION
## Why

The track server (CherryPy, 50-thread pool, 50ms socket timeouts) intermittently logs libmemcached errors on `email_recs` writes/deletes against a healthy memcached:

- `MEMCACHED_END` (21) on `memcached_set`, a reply terminator read where `STORED` was expected
- `MEMCACHED_ERRNO` + `EBADF` (26) on `memcached_delete`, an op against an already-closed socket
- `MEMCACHED_TIMEOUT` (31) "No active_fd" on `memcached_set`

`pylibmc.Client` is not safe to share across threads: pylibmc releases the GIL during socket I/O, so two threads on the same client interleave reads and writes on one connection and desync the protocol. `ElastiCache._cache` cached one client on the shared backend instance, so all 50 worker threads shared it.

A per-thread client fixes the race but multiplies connections by thread count: 16 procs/box x 50 threads x 20 pods = ~16k connections per node. A bounded pool fixes the race while capping connections at `POOL_SIZE * procs/box * pods`.

NB: The per-thread client was implemented in #5 but never deployed.

## How

`ElastiCache` now keeps a `pylibmc.ClientPool` per process and reserves a client from it for each cache operation, so no client is used by two threads at once.

**`PooledClient` proxy:** routes every operation through `pool.get()`/`pool.put()` directly (bypassing `reserve()`, which doesn't expose a timeout). Uses `__getattr__` to cover all pylibmc client methods without a per-method override. Raises `QueueEmpty` on pool exhaustion; callers such as `KeyCheckingMemcache` catch and handle it like any other cache error.

**`invalidate_cache_after_error`:** wraps `get`, `get_many`, `set`, `set_many`, and `delete`. On any exception other than `QueueEmpty`, clears the node cache and pool so both are rebuilt on the next call. `QueueEmpty` is passed through without clearing since pool exhaustion is not a topology error.

**`_cache` property:** builds the pool lazily under `_pool_lock` (needs cluster discovery first). Double-checked locking prevents two threads from each building a pool on first use.

**`clear_cluster_nodes_cache`:** acquires `_pool_lock` before clearing `_cluster_nodes_cache` and `_pool_proxy`, preventing a concurrent `_cache` build from overwriting the cleared proxy with a pool built against stale nodes.

**`POOL_SIZE`:** top-level param (sibling of `OPTIONS`, like `DISCOVERY_TIMEOUT`). Validated as a plain positive integer; booleans and non-integers raise `InvalidCacheBackendError`. Defaults to 8. With 8, connections per node = ~2.6k vs ~16k for per-thread.

**`POOL_TIMEOUT_MS`:** top-level param, milliseconds to wait for a free client. Validated as a plain positive integer. Defaults to 1000ms. Stored internally as seconds for `Queue.get(timeout=N)`.

## Next Steps

- Set `POOL_SIZE` and `POOL_TIMEOUT_MS` explicitly in the `monetate-cm` `backend_settings.py` jinja template for the `email_recs` cache rather than relying on defaults.
- Cut a new `django-elasticache` release and bump the pin in `monetate-server` (`backend/track-requirements.txt`).
- The `default` cache in `monetate-server` uses plain `django.core.cache.backends.memcached.PyLibMCCache`, which has the same shared-client bug and cannot use this pool. Address with a separate pooled `PyLibMCCache` subclass if needed.
