### PR TITLE
Invalidate cluster cache only on node-level pylibmc errors

### DIFF
--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -10,7 +10,7 @@ Top-level configuration params (siblings of ``OPTIONS``, like ``DISCOVERY_TIMEOU
 
 - ``POOL_SIZE`` (int, default 8): number of pooled clients per process.
 - ``POOL_TIMEOUT_MS`` (int, milliseconds, default 1000): how long to wait for a free client before raising
-  ``QueueEmpty``. Callers such as ``KeyCheckingMemcache`` catch and handle this like any other cache error.
+  ``queue.Empty``. Callers such as ``KeyCheckingMemcache`` catch and handle this like any other cache error.
 
 The pool is built lazily on first use (cluster discovery must happen first) under a lock so concurrent first
 calls do not each build their own pool.
@@ -27,7 +27,7 @@ from .cluster_utils import get_cluster_info
 # Number of pooled pylibmc.Client objects per backend instance per process.
 DEFAULT_POOL_SIZE = 8
 
-# On exhaustion raises QueueEmpty.
+# On exhaustion raises queue.Empty.
 DEFAULT_POOL_TIMEOUT_MS = 1000
 
 
@@ -70,12 +70,12 @@ class PooledClient(object):
 
     def __init__(self, pool, timeout=None):
         self.pool = pool
-        self.timeout = timeout  # Seconds to wait for a free client before raising QueueEmpty.
+        self.timeout = timeout  # Seconds to wait for a free client before raising queue.Empty.
 
     def __getattr__(self, name):
         def call(*args, **kwargs):
             # ClientPool is a Queue subclass. Call get()/put() directly rather than reserve() because it does not expose
-            # a timeout parameter. Raises QueueEmpty on pool exhaustion; callers (e.g. KeyCheckingMemcache) handle it.
+            # a timeout parameter. Raises queue.Empty on pool exhaustion; callers (e.g. KeyCheckingMemcache) handle it.
             mc = self.pool.get(block=True, timeout=self.timeout)
             try:
                 return getattr(mc, name)(*args, **kwargs)

--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -41,7 +41,7 @@ def _validate_positive_int(name, value):
 def invalidate_cache_after_error(f):
     """Catch system/network-level errors and invalidate the cluster node cache and client pool so both are rebuilt on
     the next call. Only errors that indicate a node is unreachable trigger invalidation. Transient errors (timeouts,
-    dropped connections, protocol errors) and pool exhaustion propagate without clearing the node cache.
+    mid-operation read/write failures, protocol errors) and pool exhaustion propagate without clearing the node cache.
     """
     @wraps(f)
     def wrapper(self, *args, **kwds):

--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -16,17 +16,13 @@ The pool is built lazily on first use (cluster discovery must happen first) unde
 calls do not each build their own pool.
 """
 import socket
-import sys
 import threading
 from functools import wraps
+
+import pylibmc
 from django.core.cache import InvalidCacheBackendError
 from django.core.cache.backends.memcached import PyLibMCCache
 from .cluster_utils import get_cluster_info
-
-if sys.version_info[0] < 3:
-    from Queue import Empty as QueueEmpty
-else:
-    from queue import Empty as QueueEmpty
 
 # Number of pooled pylibmc.Client objects per backend instance per process.
 DEFAULT_POOL_SIZE = 8
@@ -43,19 +39,21 @@ def _validate_positive_int(name, value):
 
 
 def invalidate_cache_after_error(f):
-    """Catch exceptions from cache operations and invalidate the cluster node cache and client pool so both are
-    rebuilt on the next call. QueueEmpty (pool exhaustion) is re-raised without invalidating since it is not a
-    topology error.
+    """Catch system/network-level errors and invalidate the cluster node cache and client pool so both are rebuilt on
+    the next call. Only errors that indicate a node is unreachable trigger invalidation. Transient errors (timeouts,
+    dropped connections, protocol errors) and pool exhaustion propagate without clearing the node cache.
     """
     @wraps(f)
     def wrapper(self, *args, **kwds):
         try:
             return f(self, *args, **kwds)
-        except QueueEmpty:  # Don't clear cluster nodes on pool exhaustion.
-            raise
-        # TODO: Narrow to only invalidate on system/network-level errors. Clearing nodes on any exception is too broad
-        # and causes unnecessary rediscovery churn.
-        except Exception:
+        except (
+            pylibmc.ConnectionError,
+            pylibmc.HostLookupError,
+            pylibmc.NoServers,
+            pylibmc.ServerDead,
+            pylibmc.ServerDown,
+        ):
             self.clear_cluster_nodes_cache()
             raise
     return wrapper

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -9,6 +9,7 @@ else:
     from queue import Empty as QueueEmpty
     from unittest.mock import patch, Mock
 
+import pylibmc
 from django_elasticache.memcached import ElastiCache
 from django.core.cache import InvalidCacheBackendError
 
@@ -67,17 +68,26 @@ def test_invalid_pool_timeout_bool():
     ElastiCache('h:0', {'POOL_TIMEOUT_MS': True})
 
 
-@raises(QueueEmpty)
 @patch('django.conf.settings', global_settings)
 @patch('django_elasticache.memcached.get_cluster_info')
-def test_pool_timeout_raises_queue_empty(get_cluster_info):
+def test_pool_exhaustion_propagates_without_invalidating(get_cluster_info):
+    # Pool exhaustion surfaces as QueueEmpty, which is not a pylibmc error, so it propagates without rediscovery.
     get_cluster_info.return_value = {'nodes': ['h:p']}
-    backend = ElastiCache('h:0', {'POOL_TIMEOUT_MS': 50})
+    backend = ElastiCache('h:0', {})
     backend._lib.Client = Mock()
     mock_pool = Mock()
     mock_pool.get.side_effect = QueueEmpty()
     backend._lib.ClientPool = Mock(return_value=mock_pool)
-    backend.get('k')
+
+    raised = 0
+    for _ in range(2):
+        try:
+            backend.get('k')
+        except QueueEmpty:
+            raised += 1
+    # QueueEmpty reaches the caller untouched, and the node cache survives so the second op does not rediscover.
+    eq_(raised, 2)
+    eq_(get_cluster_info.call_count, 1)
 
 
 @patch('django.conf.settings', global_settings)
@@ -140,17 +150,30 @@ def test_node_info_cache(get_cluster_info):
     eq_(mock_client.set.call_count, 2)
 
 
+# The errors invalidate_cache_after_error should treat as system/network-level failures worth rediscovering on.
+INVALIDATING_ERRORS = [
+    pylibmc.ConnectionError,
+    pylibmc.HostLookupError,
+    pylibmc.NoServers,
+    pylibmc.ServerDead,
+    pylibmc.ServerDown,
+]
+
+
+def test_invalidate_cache():
+    # nose generator: one case per caught error. @patch lives on the check, not here, so it is active per case.
+    for error in INVALIDATING_ERRORS:
+        yield check_invalidate_cache_on_error, error
+
+
 @patch('django.conf.settings', global_settings)
 @patch('django_elasticache.memcached.get_cluster_info')
-def test_invalidate_cache(get_cluster_info):
-    servers = ['h1:p', 'h2:p']
-    get_cluster_info.return_value = {
-        'nodes': servers
-    }
+def check_invalidate_cache_on_error(error, get_cluster_info):
+    get_cluster_info.return_value = {'nodes': ['h1:p', 'h2:p']}
 
     backend = ElastiCache('h:0', {})
     mock_client = Mock()
-    mock_client.get.side_effect = Exception()
+    mock_client.get.side_effect = error()
     backend._lib.Client = Mock()
     mock_pool = Mock()
     mock_pool.get.return_value = mock_client
@@ -168,6 +191,33 @@ def test_invalidate_cache(get_cluster_info):
         pass
     eq_(mock_client.get.call_count, 2)
     eq_(get_cluster_info.call_count, 2)
+
+
+@patch('django.conf.settings', global_settings)
+@patch('django_elasticache.memcached.get_cluster_info')
+def test_transient_error_does_not_invalidate_cache(get_cluster_info):
+    # A transient error (e.g. a timeout surfacing as the base pylibmc.Error) must not trigger rediscovery.
+    get_cluster_info.return_value = {'nodes': ['h1:p', 'h2:p']}
+
+    backend = ElastiCache('h:0', {})
+    mock_client = Mock()
+    mock_client.get.side_effect = pylibmc.Error()
+    backend._lib.Client = Mock()
+    mock_pool = Mock()
+    mock_pool.get.return_value = mock_client
+    backend._lib.ClientPool = Mock(return_value=mock_pool)
+
+    try:
+        backend.get('key1', 'val')
+    except Exception:
+        pass
+    # Node cache and pool are preserved, so the next op reuses them without rediscovering.
+    try:
+        backend.get('key1', 'val')
+    except Exception:
+        pass
+    eq_(mock_client.get.call_count, 2)
+    eq_(get_cluster_info.call_count, 1)
 
 
 @patch("django.conf.settings", global_settings)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -180,15 +180,14 @@ def check_invalidate_cache_on_error(error, get_cluster_info):
     # return_value so both pool builds (before and after the error-triggered clear) get the same mock_pool.
     backend._lib.ClientPool = Mock(return_value=mock_pool)
 
-    try:
-        backend.get('key1', 'val')
-    except Exception:
-        pass
-    # On error the node cache and pool are dropped, so the next op rediscovers the cluster and rebuilds.
-    try:
-        backend.get('key1', 'val')
-    except Exception:
-        pass
+    # Each call raises the caught error to the caller and drops the node cache, so the next op rediscovers.
+    raised = 0
+    for _ in range(2):
+        try:
+            backend.get('key1', 'val')
+        except error:
+            raised += 1
+    eq_(raised, 2)
     eq_(mock_client.get.call_count, 2)
     eq_(get_cluster_info.call_count, 2)
 
@@ -207,15 +206,14 @@ def test_transient_error_does_not_invalidate_cache(get_cluster_info):
     mock_pool.get.return_value = mock_client
     backend._lib.ClientPool = Mock(return_value=mock_pool)
 
-    try:
-        backend.get('key1', 'val')
-    except Exception:
-        pass
-    # Node cache and pool are preserved, so the next op reuses them without rediscovering.
-    try:
-        backend.get('key1', 'val')
-    except Exception:
-        pass
+    # The transient error reaches the caller but the node cache and pool are preserved, so the next op reuses them.
+    raised = 0
+    for _ in range(2):
+        try:
+            backend.get('key1', 'val')
+        except pylibmc.Error:
+            raised += 1
+    eq_(raised, 2)
     eq_(mock_client.get.call_count, 2)
     eq_(get_cluster_info.call_count, 1)
 


### PR DESCRIPTION
## Summary
`invalidate_cache_after_error` previously caught any `Exception` (except `QueueEmpty`) and cleared the cluster node cache and client pool, forcing ElastiCache rediscovery. That over-triggered on transient failures (timeouts, mid-operation read/write failures, protocol desync), causing needless rediscovery churn even when the cluster topology had not changed.

This narrows the catch to the five pylibmc errors that genuinely indicate a node is unreachable or the topology changed. Everything else propagates without clearing the cache.

## Why these five
Verified against pylibmc 1.6.1 and the linked libmemcached by reading each exception's `.retcode` (the libmemcached return code) and cross-checking `memcached_strerror`:

| pylibmc exception | retcode | libmemcached meaning |
|---|---|---|
| `HostLookupError` | 2 | hostname lookup failure (DNS) |
| `ConnectionError` | 3 | connection failure |
| `NoServers` | 20 | no servers defined |
| `ServerDead` | 35 | server marked dead |
| `ServerDown` | 47 | server temporarily disabled, pending retry |

Transient errors are deliberately left uncaught: `ReadError` (6), `WriteError` (5), `UnknownReadFailure` (7), `ProtocolError` (8), and `MEMCACHED_TIMEOUT` (31), which has no dedicated subclass and surfaces as the base `pylibmc.Error`, so it propagates. Pool exhaustion (`queue.Empty`) also propagates untouched, so the explicit `QueueEmpty` re-raise and its dead import were removed.

## Tests
- Parametrized the invalidation test over all five caught errors (one case each).
- Added coverage that a transient `pylibmc.Error` does not trigger rediscovery.
- Reworked the pool-exhaustion test to assert `QueueEmpty` propagates without rediscovery.
- Full suite: 21 passing.

## Notes
No version bump here; the `MONETATE_PATCH` bump will go in a separate PR.
