### PR TITLE
Add tox test matrix and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: test install tox clean
+
+test:
+	pytest
+
+install:
+	pip install -e '.[test]'
+
+# tox runs the suite on every supported interpreter (2.7 and 3.7).
+tox:
+	tox
+
+clean:
+	rm -rf .pytest_cache .tox build dist *.egg-info
+	find . -name '*.py[co]' -delete
+	find . -name __pycache__ -type d -prune -exec rm -rf {} +

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
-.PHONY: test install tox clean
+.PHONY: test install install-test test-tox clean
 
 test:
 	pytest
 
 install:
+	pip install -e .
+
+install-test:
 	pip install -e '.[test]'
 
-# tox runs the suite on every supported interpreter (2.7 and 3.7).
-tox:
+# test-tox runs the suite on every supported interpreter (2.7 and 3.7); Jenkins CI invokes this target.
+test-tox:
 	tox
 
 clean:

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Requirements
 * pylibmc
 * Django 1.5+.
 
-It was written and tested on Python 2.7 and 3.4.
+It was written and tested on Python 2.7 and 3.7.
 
 Installation
 ------------
@@ -169,3 +169,9 @@ Install the test dependencies and run the tests like this::
 
     pip install -e '.[test]'
     pytest
+
+To run the suite across the supported Python versions (2.7 and 3.7), use tox::
+
+    tox
+
+These steps are also wrapped in the Makefile as ``make install``, ``make test``, and ``make tox``.

--- a/README.rst
+++ b/README.rst
@@ -174,4 +174,4 @@ To run the suite across the supported Python versions (2.7 and 3.7), use tox::
 
     tox
 
-These steps are also wrapped in the Makefile as ``make install``, ``make test``, and ``make tox``.
+These steps are also wrapped in the Makefile as ``make install-test``, ``make test``, and ``make test-tox``.

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(
             "pytest>=4.6; python_version >= '3.0'",
             "mock; python_version < '3.0'",
         ],
+        # Orchestration tooling for the outer env. tox builds and runs the per-version test envs.
+        "dev": ["tox"],
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,11 @@ setup(
     extras_require={
         # Install with `pip install -e '.[test]'`. mock is the py2 backport of py3's stdlib unittest.mock.
         "test": [
+            "mock; python_version < '3.0'",
             "pytest>=4.6,<5.0; python_version < '3.0'",
             "pytest>=4.6; python_version >= '3.0'",
-            "mock; python_version < '3.0'",
+            "tox",
         ],
-        # Orchestration tooling for the outer env. tox builds and runs the per-version test envs.
-        "dev": ["tox"],
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,14 @@
 [tox]
 envlist = py27, py37
+skip_missing_interpreters = False
 
 [testenv]
 # Pin Django to the 1.11 series this package targets, the last release that runs on both 2.7 and 3.7
 # and still ships smart_text and PyLibMCCache that the backend imports.
-extras = test
 deps = Django>=1.11,<2.0
-commands = pytest {posargs}
+setenv =
+    PYTHONPATH = {toxinidir}
+commands =
+    pip install -U pip
+    pip install -e .[test]
+    pytest --basetemp={envtmpdir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py37
+
+[testenv]
+# Pin Django to the 1.11 series this package targets, the last release that runs on both 2.7 and 3.7
+# and still ships smart_text and PyLibMCCache that the backend imports.
+extras = test
+deps = Django>=1.11,<2.0
+commands = pytest {posargs}


### PR DESCRIPTION
# Why

The suite runs on pytest (merged in #10), but there is no matrix runner, no single entry point for the test commands, and nothing CI can invoke yet. This sets up the tox test tooling for Python 2.7 and 3.7 and a Makefile, with tox added to the `test` extra, structured to match the monetate library CI pattern (e.g. monetate-caching) so a follow-up PR can wire it into Jenkins. The Jenkinsfile ships separately.

# How

- `tox.ini`: `py27` and `py37` environments. Each runs `pip install -U pip`, `pip install -e .[test]`, then `pytest`. Django is pinned to the 1.11 series (the last release that runs on both interpreters and still ships the `smart_text` and `PyLibMCCache` symbols the backend imports). `skip_missing_interpreters = False` so a missing interpreter fails rather than silently passing. No hardcoded `basepython`: interpreters are selected by `PYENV_VERSION`, matching the monetate-caching pattern so the future Jenkins stage can drive it.
- `Makefile`: `test` (default, runs `pytest`), `install` (`pip install -e .`, no test deps), `install-test` (`pip install -e '.[test]'`), `test-tox` (`tox`, the entry point CI will invoke), and `clean`.
- `setup.py`: adds `tox` to the `test` extra, so `pip install -e '.[test]'` provides the matrix runner alongside pytest. No `install_requires` or library-code changes.
- README documents the make shortcuts and bumps the supported-versions line from 3.4 to 3.7.

# Next Steps
- Cleanup any errors after running tests in py37 venv
- Jenkins setup for auto running tests

# Validation

1. `make install-test` (or `pip install -e '.[test]'`). Expect the package, pytest, and tox to install; on Python 3 the `mock` backport is correctly skipped. `make install` installs the package alone, without the test deps.
2. `make test` (or `pytest`). Expect the 28 existing tests to pass: 21 in `tests/test_backend.py` and 7 in `tests/test_protocol.py`.
3. `make test-tox` (or `tox`) to run the matrix. Expect the same 28 tests to pass on each interpreter. The py27 env has been run this way locally (28 passed). py37 needs libmemcached present so the `pylibmc` C extension builds.
4. `make clean`. Expect `.pytest_cache`, `.tox`, build/egg-info, and compiled artifacts to be removed.
