### PR TITLE
Decode cluster version to str for py3 compatibility

### DIFF
--- a/django_elasticache/cluster_utils.py
+++ b/django_elasticache/cluster_utils.py
@@ -52,7 +52,7 @@ def get_cluster_info(host, port, discovery_timeout, ignore_cluster_errors=False)
 
     if res == b'ERROR\r\n' and ignore_cluster_errors:
         return {
-            'version': version,
+            'version': smart_text(version),
             'nodes': [
                 '{0}:{1}'.format(smart_text(host),
                                smart_text(port))


### PR DESCRIPTION
# Why

Running the test suite on Python 3.7 (which the nose-era CI never exercised) surfaced a real py3 bug: `get_cluster_info` returns the cluster version as bytes in the `ignore_cluster_errors` branch (`b'1.4.34'` instead of `'1.4.34'`). Python 2 hid it because `bytes == str` compares equal there; on Python 3 it does not, so `test_no_configuration_protocol_support_with_errors_ignored` fails with `assert b'1.4.34' == '1.4.34'`.

```shell
================================================================== FAILURES ===================================================================
_________________________________________ test_no_configuration_protocol_support_with_errors_ignored __________________________________________

Telnet = <MagicMock name='Telnet' id='4394537160'>

    @patch('django_elasticache.cluster_utils.Telnet')
    def test_no_configuration_protocol_support_with_errors_ignored(Telnet):
        client = Telnet.return_value
        client.read_until.side_effect = TEST_PROTOCOL_4_READ_UNTIL
        client.expect.side_effect = TEST_PROTOCOL_4_EXPECT
        info = get_cluster_info('test', 0, None, ignore_cluster_errors=True)
        client.write.assert_has_calls([
            call(b'version\n'),
            call(b'config get cluster\n'),
        ])
>       assert info['version'] == '1.4.34'
E       AssertionError: assert b'1.4.34' == '1.4.34'

tests/test_protocol.py:111: AssertionError
=========================================================== short test summary info ===========================================================
FAILED tests/test_protocol.py::test_no_configuration_protocol_support_with_errors_ignored - AssertionError: assert b'1.4.34' == '1.4.34'
======================================================== 1 failed, 27 passed in 0.21s =========================================================
```

# How

In the `ignore_cluster_errors` early return, decode `version` with `smart_text`, the same helper the function already uses for `host`/`port` and for the version comparison a few lines above. One line. The fix is scoped to that branch: the normal path returns `version` as an `int` (unchanged), and the function's docstring already advertises a string version (`'1.4.4'`).

Nothing in the package reads `info['version']` (`memcached.py` only consumes `info['nodes']`), so this is a correctness fix to the returned contract with no runtime consumer impact.

# Validation
```shell
pytest
============================================================= test session starts =============================================================
platform darwin -- Python 3.7.17, pytest-7.4.4, pluggy-1.2.0
rootdir: /Users/riccardomaio/monetate-claude/django-elasticache
configfile: pytest.ini
testpaths: tests
collected 28 items

tests/test_backend.py .....................                                                                                             [ 75%]
tests/test_protocol.py .......                                                                                                          [100%]

============================================================= 28 passed in 0.06s ==============================================================

```