### PR TITLE
bump django-elasticache 1.0.3+monetate.6 -> 1.0.3+monetate.7

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.0.3+monetate.6
+1.0.3+monetate.7

--- a/django_elasticache/__init__.py
+++ b/django_elasticache/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.3+monetate.6"
+__version__ = "1.0.3+monetate.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.3+monetate.6
+current_version = 1.0.3+monetate.7
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\+monetate\.(?P<monetate>\d+)$
 serialize = {major}.{minor}.{patch}+monetate.{monetate}
@@ -14,3 +14,4 @@ replace = __version__ = "{new_version}"
 
 [bdist_wheel]
 universal = 1
+


### PR DESCRIPTION
# Why

Deploy changes from:
- https://github.com/monetate/django-elasticache/pull/9
- https://github.com/monetate/django-elasticache/pull/10
- https://github.com/monetate/django-elasticache/pull/11
- https://github.com/monetate/django-elasticache/pull/12
- https://github.com/monetate/django-elasticache/pull/13
- https://github.com/monetate/django-elasticache/pull/14

NB: PRs 10-14 do not affect any behavior of this package. They are only related to tests & CI/CD pipeline.
